### PR TITLE
bugfix for issue #3

### DIFF
--- a/CloudCoderModelClasses/src/org/cloudcoder/app/shared/model/Problem.java
+++ b/CloudCoderModelClasses/src/org/cloudcoder/app/shared/model/Problem.java
@@ -288,7 +288,8 @@ public class Problem extends ProblemData implements IProblem, ActivityObject, IM
 				&& this.whenAssigned == other.whenAssigned
 				&& this.whenDue == other.whenDue
 				&& this.visible == other.visible
-				&& this.problemAuthorship == other.problemAuthorship;
+				&& this.problemAuthorship == other.problemAuthorship
+				&& this.deleted == other.deleted;
 	}
 
 	/*

--- a/CloudCoderModelClasses/src/org/cloudcoder/app/shared/model/ProblemAndTestCaseList.java
+++ b/CloudCoderModelClasses/src/org/cloudcoder/app/shared/model/ProblemAndTestCaseList.java
@@ -110,6 +110,10 @@ public class ProblemAndTestCaseList implements ActivityObject, IProblemAndTestCa
 
 	/**
 	 * Copy all data in the given ProblemAndTestCaseList object into this one.
+	 * To the extent possible, the {@link Problem} object and {@link TestCase}
+	 * objects in this ProblemAndTestCaseList will be modified in place,
+	 * rather than a new {@link Problem} and {@link TestCase}s being
+	 * created. 
 	 * 
 	 * @param other another ProblemAndTestCaseList object
 	 */
@@ -117,16 +121,30 @@ public class ProblemAndTestCaseList implements ActivityObject, IProblemAndTestCa
 		if (other.problem == null) {
 			this.problem = null;
 		} else {
-			this.problem = new Problem();
+			if (this.problem == null) {
+				this.problem = new Problem();
+			}
 			this.problem.copyFrom(other.problem);
 		}
 
 		if (other.testCaseList == null) {
 			this.testCaseList = null;
 		} else {
-			this.testCaseList = new TestCase[other.testCaseList.length];
+			if (this.testCaseList.length != other.testCaseList.length) {
+				int min = Math.min(this.testCaseList.length, other.testCaseList.length);
+				TestCase[] newTestCaseList = new TestCase[other.testCaseList.length];
+				// Preserve as many existing TestCase objects as possible
+				for (int i = 0; i < min; i++) {
+					newTestCaseList[i] = this.testCaseList[i];
+				}
+				// Create new TestCase objects if the list has been expanded
+				for (int i = min; i < newTestCaseList.length; i++) {
+					newTestCaseList[i] = new TestCase();
+				}
+				this.testCaseList = newTestCaseList;
+			}
+			//this.testCaseList = new TestCase[other.testCaseList.length];
 			for (int i = 0; i < other.testCaseList.length; i++) {
-				this.testCaseList[i] = new TestCase();
 				this.testCaseList[i].copyFrom(other.testCaseList[i]);
 			}
 		}

--- a/CloudCoderModelClasses/src/org/cloudcoder/app/shared/model/ProblemData.java
+++ b/CloudCoderModelClasses/src/org/cloudcoder/app/shared/model/ProblemData.java
@@ -397,7 +397,8 @@ public class ProblemData implements Serializable, IProblemData {
 				&& ModelObjectUtil.equals(this.authorEmail, other.authorEmail)
 				&& ModelObjectUtil.equals(this.authorWebsite, other.authorWebsite)
 				&& this.timestampUTC == other.timestampUTC
-				&& ModelObjectUtil.equals(this.license, other.license);
+				&& ModelObjectUtil.equals(this.license, other.license)
+				&& ModelObjectUtil.equals(this.parentHash, other.parentHash);
 	}
 
 	/*

--- a/CloudCoderModelClassesTest/tests/org/cloudcoder/app/shared/model/ProblemAndTestCaseListTest.java
+++ b/CloudCoderModelClassesTest/tests/org/cloudcoder/app/shared/model/ProblemAndTestCaseListTest.java
@@ -1,0 +1,51 @@
+package org.cloudcoder.app.shared.model;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProblemAndTestCaseListTest {
+	private ProblemAndTestCaseList first, second;
+	
+	@Before
+	public void setUp() {
+		first = new ProblemAndTestCaseList();
+		second = new ProblemAndTestCaseList();
+		
+		first.setProblem(new Problem());
+		second.setProblem(new Problem());
+		
+		TestCase t1 = new TestCase();
+		t1.setTestCaseName("t1");
+		TestCase t2 = new TestCase();
+		t2.setTestCaseName("t2");
+		TestCase t3 = new TestCase();
+		t3.setTestCaseName("t3");
+		
+		first.setTestCaseList(new TestCase[]{t1});
+		
+		second.setTestCaseList(new TestCase[]{t2, t3});
+	}
+	
+	@Test
+	public void testCopyFrom() throws Exception {
+		assertEquals(1, first.getTestCaseList().length);
+		assertEquals("t1", first.getTestCaseList()[0].getTestCaseName());
+		int probId = System.identityHashCode(first.getProblem());
+		int firstTestCaseId = System.identityHashCode(first.getTestCaseList()[0]);
+		
+		first.copyFrom(second);
+		
+		// TestCase data should match copied ProblemAndTestCaseList
+		assertEquals(2, first.getTestCaseList().length);
+		assertEquals("t2", second.getTestCaseList()[0].getTestCaseName());
+		assertEquals("t3", second.getTestCaseList()[1].getTestCaseName());
+		
+		// Identities of Problem and first TestCase should not have changed:
+		// copyFrom() should always attempt to preserve existing Problem/TestCase
+		// objects when possible.
+		assertEquals(probId, System.identityHashCode(first.getProblem()));
+		assertEquals(firstTestCaseId, System.identityHashCode(first.getTestCaseList()[0]));
+	}
+}


### PR DESCRIPTION
The problem was that ProblemAndTestCaseList.copyFrom was allocating
a new Problem object rather than copying data into the
existing one.  The EditProblemAdapter didn't know about the new
Problem object, and was continuing to edit the old one.

Fixed the issue by changing ProblemAndTestCaseList.copyFrom to
always reuse Problem/TestCase objects when possible.

Also made a couple improvements to equals methods for Problem
and ProblemData.
